### PR TITLE
Updated examples. (#162)

### DIFF
--- a/examples/ammo.html
+++ b/examples/ammo.html
@@ -3,7 +3,7 @@
   <head>
     <title>Examples • AmmoDriver</title>
     <meta name="description" content="Hello, WebVR! - A-Frame" />
-    <script src="https://aframe.io/releases/0.9.1/aframe.min.js"></script>
+    <script src="https://aframe.io/releases/1.0.4/aframe.min.js"></script>
     <script src="https://mixedreality.mozilla.org/ammo.js/builds/ammo.wasm.js"></script>
     <script src="../bundle.js"></script>
     <script>

--- a/examples/cannon.html
+++ b/examples/cannon.html
@@ -3,7 +3,7 @@
   <head>
     <title>Examples • CannonDriver</title>
     <meta name="description" content="Hello, WebVR! - A-Frame">
-    <script src="https://aframe.io/releases/0.9.1/aframe.min.js"></script>
+    <script src="https://aframe.io/releases/1.0.4/aframe.min.js"></script>
     <script src="../bundle.js"></script>
     <script>
       AFRAME.registerComponent('bounce', {
@@ -32,10 +32,11 @@
   <body>
     <a-scene physics="debug: false; gravity: -9.8;">
       <a-camera near=0.001></a-camera>
+
       <a-box position="-1 5 -5" rotation="0 45 0" color="#4CC3D9" shadow body="shape: box;"></a-box>
       <a-box id="target" position="1 3.75 -4" rotation="0 45 0" color="purple" shadow body="shape: box;"></a-box>
       <a-sphere position="0 10 -10" radius="1.25" color="#EF2D5E" shadow body="shape: sphere;"></a-sphere>
-      <a-cone position="0 3.75 -4" radius-bottom="1.25" color="green" shadow bounce body="type: static; mass:  shape: cone; addCollideEventListener: true; collisionFlags: 4" constraint="target: #target;"></a-cone>
+      <a-cone position="0 3.75 -4" radius-bottom="1.25" color="green" shadow bounce body="type: static; shape: cone; addCollideEventListener: true; collisionFlags: 4" constraint="target: #target;"></a-cone>
       <a-torus position="-1 3.75 -7" radius="1.25" scale="0.5 0.5 0.5" color="red" shadow body="shape: capsule; cylinderAxis: z;"></a-torus>
       <a-torus-knot position="0 3.75 -5" radius="1.25" scale="0.5 0.5 0.5" color="blue" shadow body="addCollideEventListener: false;"></a-torus-knot>
       <a-cylinder segments-height="1" segments-radial="10" position="1 4.0 -5" radius="0.5" height="1.5" color="#FFC65D" shadow body="shape: cylinder"></a-cylinder>

--- a/examples/compound.html
+++ b/examples/compound.html
@@ -4,10 +4,10 @@
     <meta http-equiv="content-type" content="text/html; charset=utf-8">
     <meta name="viewport" content="width=device-width,initial-scale=1,shrink-to-fit=no,user-scalable=no,maximum-scale=1">
     <title>Examples • Compound</title>
-    <script src="https://aframe.io/releases/0.9.1/aframe.min.js"></script>
+    <script src="https://aframe.io/releases/1.0.4/aframe.min.js"></script>
     <script src="https://rawgit.com/feiss/aframe-environment-component/master/dist/aframe-environment-component.min.js"></script>
     <script src="https://cdn.rawgit.com/donmccurdy/aframe-extras/v4.2.0/dist/components/sphere-collider.js"></script>
-    <script src="bundle.js"></script>
+    <script src="../bundle.js"></script>
     <script src="components/force-pushable.js"></script>
   </head>
   <body>
@@ -19,8 +19,8 @@
                   geometry="primitive: circle; radius: 0.01; segments: 4;"
                   material="color: #FF4444; shader: flat"></a-entity>
       </a-entity>
-      <a-entity static-body="shape: sphere; sphereRadius: 0.02;" vive-controls="hand: left" sphere-collider="objects: [dynamic-body];" grab></a-entity>
-      <a-entity static-body="shape: sphere; sphereRadius: 0.02;" vive-controls="hand: right" sphere-collider="objects: [dynamic-body];" grab></a-entity>
+      <a-entity static-body="shape: sphere; sphereRadius: 0.02;" hand-controls="hand: left" sphere-collider="objects: [dynamic-body];" grab></a-entity>
+      <a-entity static-body="shape: sphere; sphereRadius: 0.02;" hand-controls="hand: right" sphere-collider="objects: [dynamic-body];" grab></a-entity>
 
       <!-- Terrain -->
       <a-box width="75" height="0.1" depth="75" static-body visible="false"></a-box>

--- a/examples/constraints.html
+++ b/examples/constraints.html
@@ -5,7 +5,7 @@
     <meta http-equiv="content-type" content="text/html; charset=utf-8">
     <meta name="viewport" content="width=device-width,initial-scale=1,shrink-to-fit=no,user-scalable=no,maximum-scale=1">
     <title>Examples • Constraints</title>
-    <script type="text/javascript" src="https://aframe.io/releases/0.9.1/aframe.min.js"></script>
+    <script type="text/javascript" src="https://aframe.io/releases/1.0.4/aframe.min.js"></script>
     <script src="https://rawgit.com/feiss/aframe-environment-component/master/dist/aframe-environment-component.min.js"></script>
     <script src="https://rawgit.com/fernandojsg/aframe-teleport-controls/master/dist/aframe-teleport-controls.min.js"></script>
     <script src="https://cdn.rawgit.com/donmccurdy/aframe-extras/v4.2.0/dist/components/sphere-collider.js"></script>
@@ -14,8 +14,8 @@
   </head>
   <body>
     <a-scene environment>
-      <a-entity teleport-controls vive-controls="hand: left" static-body="shape: sphere; sphereRadius: 0.02;" sphere-collider="objects: [dynamic-body];" grab></a-entity>
-      <a-entity teleport-controls vive-controls="hand: right" static-body="shape: sphere; sphereRadius: 0.02;" sphere-collider="objects: [dynamic-body];" grab></a-entity>
+      <a-entity teleport-controls hand-controls="hand: left" static-body="shape: sphere; sphereRadius: 0.02;" sphere-collider="objects: [dynamic-body];" grab></a-entity>
+      <a-entity teleport-controls hand-controls="hand: right" static-body="shape: sphere; sphereRadius: 0.02;" sphere-collider="objects: [dynamic-body];" grab></a-entity>
 
       <!-- CONE TWIST -->
       <a-entity position="2 0 -1">

--- a/examples/materials.html
+++ b/examples/materials.html
@@ -4,10 +4,10 @@
     <meta http-equiv="content-type" content="text/html; charset=utf-8">
     <meta name="viewport" content="width=device-width,initial-scale=1,shrink-to-fit=no,user-scalable=no,maximum-scale=1">
     <title>Examples • Materials</title>
-    <script src="https://aframe.io/releases/0.9.1/aframe.min.js"></script>
+    <script src="https://aframe.io/releases/1.0.4/aframe.min.js"></script>
     <script src="https://rawgit.com/feiss/aframe-environment-component/master/dist/aframe-environment-component.min.js"></script>
     <script src="https://cdn.rawgit.com/donmccurdy/aframe-extras/v3.2.5/dist/components/sphere-collider.js"></script>
-    <script src="bundle.js"></script>
+    <script src="../bundle.js"></script>
     <script src="components/force-pushable.js"></script>
   </head>
   <body>
@@ -21,8 +21,8 @@
                   geometry="primitive: circle; radius: 0.01; segments: 4;"
                   material="color: #FF4444; shader: flat"></a-entity>
       </a-entity>
-      <a-entity static-body="shape: sphere; sphereRadius: 0.02;" vive-controls="hand: left" sphere-collider="objects: [dynamic-body];" grab></a-entity>
-      <a-entity static-body="shape: sphere; sphereRadius: 0.02;" vive-controls="hand: right" sphere-collider="objects: [dynamic-body];" grab></a-entity>
+      <a-entity static-body="shape: sphere; sphereRadius: 0.02;" hand-controls="hand: left" sphere-collider="objects: [dynamic-body];" grab></a-entity>
+      <a-entity static-body="shape: sphere; sphereRadius: 0.02;" hand-controls="hand: right" sphere-collider="objects: [dynamic-body];" grab></a-entity>
 
       <!-- Terrain -->
       <a-box width="75" height="0.1" depth="75" static-body visible="false"></a-box>

--- a/examples/spring.html
+++ b/examples/spring.html
@@ -4,7 +4,7 @@
     <meta http-equiv="content-type" content="text/html; charset=utf-8">
     <meta name="viewport" content="width=device-width,initial-scale=1,shrink-to-fit=no,user-scalable=no,maximum-scale=1">
     <title>Examples • Spring</title>
-    <script type="text/javascript" src="https://aframe.io/releases/0.9.1/aframe.min.js"></script>
+    <script type="text/javascript" src="https://aframe.io/releases/1.0.4/aframe.min.js"></script>
     <script src="../bundle.js"></script>
   </head>
   <body>

--- a/examples/stress.html
+++ b/examples/stress.html
@@ -4,10 +4,10 @@
     <meta http-equiv="content-type" content="text/html; charset=utf-8">
     <meta name="viewport" content="width=device-width,initial-scale=1,shrink-to-fit=no,user-scalable=no,maximum-scale=1">
     <title>Examples • Stress Test</title>
-    <script src="https://aframe.io/releases/0.9.1/aframe.min.js"></script>
+    <script src="https://aframe.io/releases/1.0.4/aframe.min.js"></script>
     <script src="https://rawgit.com/feiss/aframe-environment-component/master/dist/aframe-environment-component.min.js"></script>
     <script src="https://cdn.rawgit.com/donmccurdy/aframe-extras/v4.2.0/dist/components/sphere-collider.js"></script>
-    <script src="bundle.js"></script>
+    <script src="../bundle.js"></script>
     <script src="components/force-pushable.js"></script>
   </head>
   <body>
@@ -22,8 +22,8 @@
                   material="color: #FF4444; shader: flat"></a-entity>
       </a-entity>
 
-      <a-entity static-body="shape: sphere; sphereRadius: 0.02;" vive-controls="hand: left" sphere-collider="objects: [dynamic-body];" grab></a-entity>
-      <a-entity static-body="shape: sphere; sphereRadius: 0.02;" vive-controls="hand: right" sphere-collider="objects: [dynamic-body];" grab></a-entity>
+      <a-entity static-body="shape: sphere; sphereRadius: 0.02;" hand-controls="hand: left" sphere-collider="objects: [dynamic-body];" grab></a-entity>
+      <a-entity static-body="shape: sphere; sphereRadius: 0.02;" hand-controls="hand: right" sphere-collider="objects: [dynamic-body];" grab></a-entity>
 
       <!-- Terrain -->
       <a-box width="75" height="0.1" depth="75" static-body visible="false"></a-box>

--- a/examples/sweeper.html
+++ b/examples/sweeper.html
@@ -4,10 +4,10 @@
     <meta http-equiv="content-type" content="text/html; charset=utf-8">
     <meta name="viewport" content="width=device-width,initial-scale=1,shrink-to-fit=no,user-scalable=no,maximum-scale=1">
     <title>Examples • Sweeper</title>
-    <script src="https://aframe.io/releases/0.9.1/aframe.min.js"></script>
+    <script src="https://aframe.io/releases/1.0.4/aframe.min.js"></script>
     <script src="https://rawgit.com/feiss/aframe-environment-component/master/dist/aframe-environment-component.min.js"></script>
     <script src="https://cdn.rawgit.com/donmccurdy/aframe-extras/v4.2.0/dist/components/sphere-collider.js"></script>
-    <script src="bundle.js"></script>
+    <script src="../bundle.js"></script>
     <script src="components/grab.js"></script>
     <script src="components/rain-of-entities.js"></script>
     <script src="components/force-pushable.js"></script>
@@ -23,8 +23,8 @@
                   geometry="primitive: circle; radius: 0.01; segments: 4;"
                   material="color: #FF4444; shader: flat"></a-entity>
       </a-entity>
-      <a-entity static-body="shape: sphere; sphereRadius: 0.02;" vive-controls="hand: left" sphere-collider="objects: [dynamic-body];" grab></a-entity>
-      <a-entity static-body="shape: sphere; sphereRadius: 0.02;" vive-controls="hand: right" sphere-collider="objects: [dynamic-body];" grab></a-entity>
+      <a-entity static-body="shape: sphere; sphereRadius: 0.02;" hand-controls="hand: left" sphere-collider="objects: [dynamic-body];" grab></a-entity>
+      <a-entity static-body="shape: sphere; sphereRadius: 0.02;" hand-controls="hand: right" sphere-collider="objects: [dynamic-body];" grab></a-entity>
 
       <!-- Terrain -->
       <a-box width="75" height="0.1" depth="75" static-body visible="false"></a-box>

--- a/examples/ttl.html
+++ b/examples/ttl.html
@@ -3,8 +3,8 @@
   <head>
     <title>Examples • TTL</title>
     <meta name="description" content="Hello, WebVR! - A-Frame">
-    <script src="https://aframe.io/releases/0.9.1/aframe.min.js"></script>
-    <script src="bundle.js"></script>
+    <script src="https://aframe.io/releases/1.0.4/aframe.min.js"></script>
+    <script src="../bundle.js"></script>
     <script>
     AFRAME.registerComponent('ttl', {
       schema: {


### PR DESCRIPTION
Updated aframe version from 0.9.1 to 1.0.4.
Replaced vive-controls with hand-controls and fixed some paths.