### PR TITLE
Reverting accidental regression in package-lock.json.

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -122,7 +122,8 @@
     },
     "ammo-debug-drawer": {
       "version": "0.1.0",
-      "resolved": "github:infinitelee/ammo-debug-drawer#0b2c323ef65b4fd414235b6a5e705cfc1201c765"
+      "resolved": "https://registry.npmjs.org/ammo-debug-drawer/-/ammo-debug-drawer-0.1.0.tgz",
+      "integrity": "sha512-GIfIf748qpfg++iXFzTB1p/M7ncJK5/X2qkg7mAQm4SPyhx93PSEejSEsZiPnk8eUUwlpyPSRMPDnpITMvlJCg=="
     },
     "an-array": {
       "version": "1.0.0",
@@ -5929,7 +5930,8 @@
     },
     "three-to-ammo": {
       "version": "0.1.0",
-      "resolved": "github:infinitelee/three-to-ammo#11830faeec9821b4a88d5e1fd130906e16174170"
+      "resolved": "https://registry.npmjs.org/three-to-ammo/-/three-to-ammo-0.1.0.tgz",
+      "integrity": "sha512-+XxlQdAlU20NHjA0As7tRUsTy9VutK6bhB+QiQx0vcET5m5t1l4/mmbXPy4aNnLnvRDWE3bepBvT8DC2OX15Jg=="
     },
     "three-to-cannon": {
       "version": "3.0.2",


### PR DESCRIPTION
package-lock.json was (probably accidentally) deleted in https://github.com/n5ro/aframe-physics-system/commit/732e8de7d3253139c72bb4aa8cdbf3eee439c245
When it was restored in https://github.com/n5ro/aframe-physics-system/commit/b0a16e22ba639ed82285eff80d8721285617b72b, the entries for ammo-debug-drawer and three-to-ammo had older values instead of the more recent values they had when the file was deleted.

This was causing a discrepancy between dist files built locally and those built by the new gitub workflow build, with the latter being incorrect since `npm ci` uses package-lock.json.