### PR TITLE
Fixed the documentation links in examples/README.md.

### DIFF
--- a/examples/README.md
+++ b/examples/README.md
@@ -4,37 +4,37 @@ To help demonstrate the features and capabilities of `aframe-physics-system`
 the following collection of examples have been prepared.
 
 - [**Ammo sandbox**](ammo.html)  
-  Demonstration of many [Ammo driver](/AmmoDriver.md) features in a single
+  Demonstration of many [Ammo driver](../AmmoDriver.md) features in a single
   example.
 
 - [**Cannon.js sandbox**](cannon.html)  
   Demonstration of many Cannon driver features in a single example.
 
 - [**Compound**](compound.html)  
-  Construct a [compound shape](/README.md#shape) and simulate collision with
+  Construct a [compound shape](../README.md#shape) and simulate collision with
   a ground plane using the Cannon driver.
 
 - [**Constraints with Ammo**](constraints-ammo.html)  
   Demonstration of many
-  [Ammo driver constraints](/AmmoDriver.md#ammo-constraint) including cone
+  [Ammo driver constraints](../AmmoDriver.md#ammo-constraint) including cone
   twist, hinge, lock, point to point, and slider constraints.
 
 - [**Constraints with Cannon**](constraints.html)  
   Demonstration of many
-  [Cannon driver constraints](/README.md#constraint) including cone twist,
+  [Cannon driver constraints](../README.md#constraint) including cone twist,
   hinge, lock, point to point, and distance constraints.
 
 - [**Materials**](materials.html)  
   Bounce simulation with
-  [restitution (bounciness)](/README.md#system-configuration) of 1 using the
+  [restitution (bounciness)](../README.md#system-configuration) of 1 using the
   Cannon driver.
 
 - [**Spring**](spring.html)  
-  Four vertical [springs](/README.md#spring) each between two boxes with an
+  Four vertical [springs](../README.md#spring) each between two boxes with an
   assortment of damping and stiffness values using the Cannon driver.
 
 - [**Stress**](stress.html)  
-  Apply [strong impulse](/README.md#using-the-cannonjs-api) to a cube when the
+  Apply [strong impulse](../README.md#using-the-cannonjs-api) to a cube when the
   user clicks with a mouse using the Cannon driver. Cubes are arranged in four
   4x3 walls.
 
@@ -43,5 +43,5 @@ the following collection of examples have been prepared.
   using the velocity component and the Cannon driver.
 
 - [**Time to live**](ttl.html)  
-  Remove a [dynamic body](README.md#dynamic-body-and-static-body) from the
+  Remove a [dynamic body](../README.md#dynamic-body-and-static-body) from the
   scene after 100 frames using the Cannon driver.


### PR DESCRIPTION
The links can be tested here:
https://mignonbelongie.github.io/aframe-physics-system/examples/
and here:
https://github.com/MignonBelongie/aframe-physics-system/blob/master/examples/README.md